### PR TITLE
Add type generation for current toolkit packages

### DIFF
--- a/packages/auth/package-lock.json
+++ b/packages/auth/package-lock.json
@@ -1748,8 +1748,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1770,14 +1769,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1792,20 +1789,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1922,8 +1916,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1935,7 +1928,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1950,7 +1942,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1958,14 +1949,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -1984,7 +1973,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2065,8 +2053,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2078,7 +2065,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2164,8 +2150,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2201,7 +2186,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2221,7 +2205,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2265,14 +2248,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -15,6 +15,7 @@
   "files": [
     "src"
   ],
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "prebuild": "rimraf dist/",
     "build": "rollup -c rollup.config.ts",

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
-    "declaration": false,
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
     "experimentalDecorators": true,
     "lib": [
       "dom",

--- a/packages/custom-viz/package.json
+++ b/packages/custom-viz/package.json
@@ -15,6 +15,7 @@
   "files": [
     "src"
   ],
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "prebuild": "rimraf dist/",
     "build": "rollup -c rollup.config.ts",

--- a/packages/custom-viz/tsconfig.json
+++ b/packages/custom-viz/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
-    "declaration": false,
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
     "experimentalDecorators": true,
     "lib": [
       "dom",

--- a/packages/maps/package-lock.json
+++ b/packages/maps/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "@carto/toolkit",
+	"name": "@carto/toolkit-maps",
 	"version": "0.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -215,14 +215,6 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"@jest/console": {
@@ -905,9 +897,9 @@
 			"dev": true
 		},
 		"builtin-modules": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+			"integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
 			"dev": true
 		},
 		"cache-base": {
@@ -1278,9 +1270,9 @@
 			"dev": true
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.2.tgz",
+			"integrity": "sha512-gUSUszrsxlDnUbUwEI9Oygyrk4ZEWtVaHQc+uZHphVeNxl+qeqMV/jDWoTkjN1RmGlZ5QWAP7o458p/JMlikQg==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
@@ -1341,20 +1333,12 @@
 				"esutils": "^2.0.2",
 				"optionator": "^0.8.1",
 				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-					"dev": true
-				}
 			}
 		},
 		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
 			"dev": true
 		},
 		"estraverse": {
@@ -2326,9 +2310,9 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-			"integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.1.tgz",
+			"integrity": "sha512-bqPIlDk06UWbVEIFoYj+LVo42WhK96J+b25l7hbFDpxrOXMphFM3fNIm+cluwg4Pk2jiLjWU5nHQY7igGE75NQ==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -3241,6 +3225,14 @@
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				}
 			}
 		},
 		"jsbn": {
@@ -3320,14 +3312,6 @@
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"jsonfile": {
@@ -3543,9 +3527,9 @@
 			}
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true
 		},
 		"mixin-deep": {
@@ -3576,6 +3560,14 @@
 			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
 			}
 		},
 		"ms": {
@@ -3783,6 +3775,14 @@
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				}
 			}
 		},
 		"optionator": {
@@ -4235,14 +4235,6 @@
 				"is-module": "^1.0.0",
 				"resolve": "^1.11.1",
 				"rollup-pluginutils": "^2.8.1"
-			},
-			"dependencies": {
-				"builtin-modules": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-					"integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
-					"dev": true
-				}
 			}
 		},
 		"rollup-plugin-sourcemaps": {
@@ -4266,12 +4258,23 @@
 				"resolve": "1.12.0",
 				"rollup-pluginutils": "2.8.1",
 				"tslib": "1.10.0"
+			},
+			"dependencies": {
+				"rollup-pluginutils": {
+					"version": "2.8.1",
+					"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
+					"integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
+					"dev": true,
+					"requires": {
+						"estree-walker": "^0.6.1"
+					}
+				}
 			}
 		},
 		"rollup-pluginutils": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
-			"integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
 			"dev": true,
 			"requires": {
 				"estree-walker": "^0.6.1"
@@ -4319,14 +4322,6 @@
 				"micromatch": "^3.1.4",
 				"minimist": "^1.1.1",
 				"walker": "~1.0.5"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"sax": {
@@ -4911,6 +4906,14 @@
 				"semver": "^5.3.0",
 				"tslib": "^1.8.0",
 				"tsutils": "^2.29.0"
+			},
+			"dependencies": {
+				"builtin-modules": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+					"dev": true
+				}
 			}
 		},
 		"tsutils": {

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -15,6 +15,7 @@
   "files": [
     "src"
   ],
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "prebuild": "rimraf dist/",
     "build": "rollup -c rollup.config.ts",

--- a/packages/maps/src/index.ts
+++ b/packages/maps/src/index.ts
@@ -1,17 +1,17 @@
 import { Credentials } from '@carto/toolkit-auth';
 
 class Maps {
-  private _credentials: any; // TODO specify Credentials type
+  private _credentials: Credentials;
 
   constructor(username: string, apiKey: string) {
     this._credentials = new Credentials(username, apiKey);
   }
 
-  public get credentials(): any {
+  public get credentials(): Credentials {
     return this._credentials;
   }
 
-  public set credentials(value: any) {
+  public set credentials(value: Credentials) {
     this._credentials = value;
   }
 

--- a/packages/maps/tsconfig.json
+++ b/packages/maps/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
-    "declaration": false,
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
     "experimentalDecorators": true,
     "lib": [
       "dom",

--- a/packages/sql/package-lock.json
+++ b/packages/sql/package-lock.json
@@ -1748,8 +1748,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1770,14 +1769,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1792,20 +1789,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1922,8 +1916,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1935,7 +1928,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1950,7 +1942,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1958,14 +1949,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -1984,7 +1973,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2065,8 +2053,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2078,7 +2065,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2164,8 +2150,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2201,7 +2186,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2221,7 +2205,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2265,14 +2248,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -15,6 +15,7 @@
   "files": [
     "src"
   ],
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "prebuild": "rimraf dist/",
     "build": "rollup -c rollup.config.ts",

--- a/packages/sql/tsconfig.json
+++ b/packages/sql/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
-    "declaration": false,
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
     "experimentalDecorators": true,
     "lib": [
       "dom",


### PR DESCRIPTION
I've enabled type module generation in TSC config for all packages.

Definitions are set to be generated in `dist/types` folder, so they won't be committed to the repository but they will be generated whenever TSC is run.