### PR TITLE
feature(maps): refactor Maps

### DIFF
--- a/packages/maps/__tests__/Maps.spec.ts
+++ b/packages/maps/__tests__/Maps.spec.ts
@@ -1,9 +1,35 @@
 import Maps from '../src';
 
 describe('maps', () => {
+
   it('should have credentials', () => {
-    const m = new Maps('roman-carto', 'wadus');
-    expect(m.username).toBe('roman-carto');
+    const m = new Maps('a-user', 'wadus');
+    expect(m.username).toBe('a-user');
     expect(m.apiKey).toBe('wadus');
+  });
+
+  it('can manage different servers', () =>{
+    const m = new Maps('a-user', 'wadus');
+    expect(m.serverURL).toBe('https://a-user.carto.com');
+
+    const customServer = 'http://127.0.0.1:8181/user/{user}';
+    const m2 = new Maps('a-user', 'wadus', customServer);
+    expect(m2.serverURL).toBe('http://127.0.0.1:8181/user/a-user');
+  });
+
+  describe ('create simple map', () => {
+
+    it('fails without dataset or sql query', async () => {
+      const m = new Maps('a-user', 'wadus');
+      await expect (m.instantiateSimpleMap({})).rejects
+        .toThrowError('Please provide a dataset or a SQL query');
+    });
+
+    // TODO: extract e2e
+    // it('accepts user without apiKey for public', async () => {
+    //   const m = new Maps('cartovl', '');
+    //   await expect (m.instantiateSimpleMap({ dataset: 'populated_places'}))
+    //     .not.toThrowError('Failed to connect to Maps API with the user');
+    // });
   });
 });

--- a/packages/maps/index.html
+++ b/packages/maps/index.html
@@ -23,7 +23,7 @@
     </div>
     <label>apiKey</label>
     <div>
-      <input id="apiKey" type="text" value="default-public">
+      <input id="apiKey" type="text" value="default_public">
     </div>
     <label>dataset</label>
     <div>
@@ -51,7 +51,7 @@
 
         $result.innerText = JSON.stringify(layergroup, null, '\t');
       } catch (err){
-        $result.innerText = 'ERROR: ' + err;
+        $result.innerText = err;
       }
     }
 

--- a/packages/maps/index.html
+++ b/packages/maps/index.html
@@ -1,0 +1,61 @@
+<html>
+
+<head>
+  <title>Maps tests</title>
+  <script src="dist/maps.umd.js"></script>
+
+  <style>
+    #result {
+      background-color: beige;
+      width: auto;
+      max-height: 350px;
+      overflow: auto;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Instantiate map</h1>
+  <form onsubmit="instantiateMap(); return false;">
+    <label>username</label>
+    <div>
+      <input id="username" type="text" value="cartovl">
+    </div>
+    <label>apiKey</label>
+    <div>
+      <input id="apiKey" type="text" value="default-public">
+    </div>
+    <label>dataset</label>
+    <div>
+      <input id="dataset" type="text" value="populated_places">
+    </div>
+    <br />
+    <div>
+      <button type="submit">instantiateMap</button>
+    </div>
+  </form>
+
+  <div id="result">
+  </div>
+  <script>
+    async function instantiateMap() {
+      const $username = document.querySelector('#username').value;
+      const $apiKey = document.querySelector('#apiKey').value;
+      const $dataset = document.querySelector('#dataset').value;
+      const $result = document.querySelector('#result');
+
+      try {
+
+        const m = new maps($username, $apiKey);
+        const layergroup = await m.instantiateSimpleMap({ dataset: $dataset });
+
+        $result.innerText = JSON.stringify(layergroup, null, '\t');
+      } catch (err){
+        $result.innerText = 'ERROR: ' + err;
+      }
+    }
+
+  </script>
+</body>
+
+</html>

--- a/packages/maps/src/errors.ts
+++ b/packages/maps/src/errors.ts
@@ -1,0 +1,16 @@
+const unauthorized = (config: any) => {
+  throw new Error(
+      `Unauthorized access to Maps API: invalid combination of user ('${config.username}') and apiKey ('${config.apiKey}')`
+    );
+};
+
+const unauthorizedDataset = (config: any) => {
+  throw new Error(
+      `Unauthorized access to dataset: the provided apiKey('${config.apiKey}') doesn't provide access to the requested data`
+    );
+};
+
+export default {
+  [401 as number]: unauthorized,
+  [403 as number]: unauthorizedDataset
+};

--- a/packages/maps/src/index.ts
+++ b/packages/maps/src/index.ts
@@ -4,8 +4,8 @@ const REQUEST_GET_MAX_URL_LENGTH = 2048;
 
 class Maps {
   private _conf: any;
-  private _auth: string;
-  private _client: string;
+  private _encodedApiKey: string;
+  private _encodedClient: string;
 
   /**
    * Build an instance to interact with Maps API v1 (aka Windshaft)
@@ -22,8 +22,8 @@ class Maps {
       serverUrlTemplate: serverURL || DEFAULT_SERVER_URL_TEMPLATE
     };
 
-    this._auth = this.encodeParameter('api_key', this._conf.apiKey);
-    this._client = this.encodeParameter('client', client || DEFAULT_CLIENT_ID);
+    this._encodedApiKey = this.encodeParameter('api_key', this._conf.apiKey);
+    this._encodedClient = this.encodeParameter('client', client || DEFAULT_CLIENT_ID);
   }
 
   public get username(): string {
@@ -82,7 +82,7 @@ class Maps {
   }
 
   private makeHttpRequest(payload: any) {
-    const parameters = [this._conf.auth, this._client, this.encodeParameter('config', payload)];
+    const parameters = [this._conf.auth, this._encodedClient, this.encodeParameter('config', payload)];
     const url = this.generateUrl(this.generateMapsApiUrl(), parameters);
     if (url.length < REQUEST_GET_MAX_URL_LENGTH) {
       return this.getRequest(url);
@@ -114,7 +114,7 @@ class Maps {
   }
 
   private postRequest(payload: any) {
-    const parameters = [this._auth, this._client];
+    const parameters = [this._encodedApiKey, this._encodedClient];
 
     return new Request(this.generateUrl(this.generateMapsApiUrl(), parameters), {
       method: 'POST',

--- a/packages/maps/src/index.ts
+++ b/packages/maps/src/index.ts
@@ -42,11 +42,11 @@ class Maps {
   }
 
   /**
-   * Instantiate a map based on dataset name or sql query, returning a layergroup
+   * Instantiate a map based on dataset name or a sql query, returning a layergroup
    *
    * @param options
    */
-  public async instantiateSimpleMap(options: { sql?: string, dataset?: string }) {
+  public async instantiateMapFrom(options: { sql?: string, dataset?: string }) {
     const { sql, dataset } = options;
 
     if (sql === undefined && dataset === undefined) {

--- a/packages/maps/src/index.ts
+++ b/packages/maps/src/index.ts
@@ -1,3 +1,4 @@
+import errorHandlers from './errors';
 import { encodeParameter, getRequest, postRequest } from './utils';
 
 const DEFAULT_SERVER_URL_TEMPLATE = 'https://{user}.carto.com';
@@ -94,15 +95,11 @@ class Maps {
     return postRequest(url, config);
   }
 
-  private dealWithWindshaftErrors(response: any, layergroup: any) {
-    if (response.status === 401) {
-      throw new Error(
-        `Unauthorized access to Maps API: invalid combination of user ('${this._conf._username}') and apiKey ('${this._conf.apiKey}')`
-      );
-    } else if (response.status === 403) {
-      throw new Error(
-        `Unauthorized access to dataset: the provided apiKey('${this._conf.apiKey}') doesn't provide access to the requested data`
-      );
+  private dealWithWindshaftErrors(response: { status: number }, layergroup: any) {
+    const errorForCode = errorHandlers[response.status];
+    if (errorForCode) {
+      errorForCode(this._conf);
+      return;
     }
     throw new Error(`${JSON.stringify(layergroup.errors)}`);
   }

--- a/packages/maps/src/index.ts
+++ b/packages/maps/src/index.ts
@@ -61,8 +61,7 @@ class Maps {
       version: '1.3.1'
     };
 
-    const layergroup = await this.instantiateMap(mapConfig);
-    return layergroup;
+    return this.instantiateMap(mapConfig);
   }
 
   private async instantiateMap(mapConfig: any) {

--- a/packages/maps/src/index.ts
+++ b/packages/maps/src/index.ts
@@ -1,54 +1,147 @@
-class Maps {
-  private _username: string;
-  private _apiKey: string;
 
-  constructor(username: string, apiKey: string) {
-    this._username = username;
-    this._apiKey = apiKey;
+const DEFAULT_SERVER_URL_TEMPLATE = 'https://{user}.carto.com';
+const DEFAULT_CLIENT_ID = 'maps-pkg';
+const REQUEST_GET_MAX_URL_LENGTH = 2048;
+
+class Maps {
+  private _conf: any;
+  private _auth: string;
+  private _client: string;
+
+  /**
+   * Build an instance to interact with Maps API v1 (aka Windshaft)
+   * @param username
+   * @param apiKey
+   * @param serverURL A url pattern like default ('https://{user}.carto.com')
+   *
+   */
+  constructor(username: string, apiKey: string, serverURL?: string, client?: string) {
+
+    this._conf = {
+      username,
+      apiKey,
+      serverUrlTemplate: serverURL || DEFAULT_SERVER_URL_TEMPLATE
+    };
+
+    this._auth = this.encodeParameter('api_key', this._conf.apiKey);
+    this._client = this.encodeParameter('client', client || DEFAULT_CLIENT_ID);
   }
 
   public get username(): string {
-    return this._username;
-  }
-
-  public set username(value: string) {
-    this._username = value;
+    return this._conf.username;
   }
 
   public get apiKey(): string {
-    return this._apiKey;
+    return this._conf.apiKey;
   }
 
-  public set apiKey(value: string) {
-    this._apiKey = value;
+  public get serverURL(): string {
+    return this._conf.serverUrlTemplate.replace('{user}', this._conf.username);
   }
 
-  public instantiateMap(options: { sql?: string, dataset?: string }) {
+  /**
+   * Instantiate a map based on dataset name or sql query, returning a layergroup
+   *
+   * Note: Get layergroup.metadata.tilejson.vector.tiles to consume MVT tiles
+   * @param options
+   */
+  public async instantiateSimpleMap(options: { sql?: string, dataset?: string }) {
     const { sql, dataset } = options;
 
     if (sql === undefined && dataset === undefined) {
       throw new Error('Please provide a dataset or a SQL query');
     }
 
-    const mapParameters = {
+    const mapConfig = {
       layers: [{
         type: 'cartodb',
         options: {
-            sql: sql || `select * from ${dataset}`
+          sql: sql || `select * from ${dataset}`
         }
       }],
       version: '1.3.1'
     };
 
-    const requestOptions = {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(mapParameters)
-    };
+    const layergroup = await this.instantiateMap(mapConfig);
+    return layergroup;
+  }
 
-    return fetch(`https://${this.username}.carto.com/api/v1/map?api_key=${this.apiKey}`, requestOptions)
-      .then((response) => response.json())
-      .then((data) => `https://${this.username}.carto.com/api/v1/map/${data.layergroupid}/{z}/{x}/{y}.mvt?api_key=${this.apiKey}`);
+  private async instantiateMap(mapConfig: any) {
+    let response;
+    try {
+      const payload = JSON.stringify(mapConfig);
+      response = await fetch(this.makeHttpRequest(payload));
+    } catch (error) {
+      throw new Error(`Failed to connect to Maps API with the user ('${this._conf.username}'): ${error}`);
+    }
+
+    const layergroup = await response.json();
+    if (!response.ok) {
+      this.dealWithWindshaftErrors(response, layergroup);
+    }
+
+    return layergroup;
+  }
+
+  private makeHttpRequest(payload: any) {
+    const parameters = [this._conf.auth, this._client, this.encodeParameter('config', payload)];
+    const url = this.generateUrl(this.generateMapsApiUrl(), parameters);
+    if (url.length < REQUEST_GET_MAX_URL_LENGTH) {
+      return this.getRequest(url);
+    }
+
+    return this.postRequest(payload);
+  }
+
+  private dealWithWindshaftErrors(response: any, layergroup: any) {
+    if (response.status === 401) {
+      throw new Error(
+        `Unauthorized access to Maps API: invalid combination of user ('${this._conf._username}') and apiKey ('${this._conf.apiKey}')`
+      );
+    } else if (response.status === 403) {
+      throw new Error(
+        `Unauthorized access to dataset: the provided apiKey('${this._conf.apiKey}') doesn't provide access to the requested data`
+      );
+    }
+    throw new Error(`${JSON.stringify(layergroup.errors)}`);
+  }
+
+  private getRequest(url: string) {
+    return new Request(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    });
+  }
+
+  private postRequest(payload: any) {
+    const parameters = [this._auth, this._client];
+
+    return new Request(this.generateUrl(this.generateMapsApiUrl(), parameters), {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: payload
+    });
+  }
+
+  private encodeParameter(name: string, value: string) {
+    return `${name}=${encodeURIComponent(value)}`;
+  }
+
+  private generateUrl(url: string, parameters: string[] = []) {
+    return `${url}?${parameters.join('&')}`;
+  }
+
+  private generateMapsApiUrl(path?: string) {
+    let url = `${this.serverURL}/api/v1/map`;
+    if (path) {
+      url += path;
+    }
+    return url;
   }
 }
 

--- a/packages/maps/src/index.ts
+++ b/packages/maps/src/index.ts
@@ -1,6 +1,5 @@
-
 const DEFAULT_SERVER_URL_TEMPLATE = 'https://{user}.carto.com';
-const DEFAULT_CLIENT_ID = 'maps-pkg';
+const DEFAULT_CLIENT_ID = 'toolkit-maps';
 const REQUEST_GET_MAX_URL_LENGTH = 2048;
 
 class Maps {

--- a/packages/maps/src/utils.ts
+++ b/packages/maps/src/utils.ts
@@ -1,0 +1,23 @@
+export function getRequest(url: string) {
+  return new Request(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  });
+}
+
+export function postRequest(url: string, payload: string) {
+  return new Request(url, {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: payload
+  });
+}
+
+export function encodeParameter(name: string, value: string) {
+  return `${name}=${encodeURIComponent(value)}`;
+}


### PR DESCRIPTION
Refactor Maps in maps package:

- Make the method a bit more generic, returning the whole layergroup --> Get **layergroup.metadata.tilejson.vector.tiles** to consume MVT tiles
- Manage request with GET or POST, based on size
- Allow custom server URL
- Add a simple `index.html` for manual tests