### PR TITLE
Retry requests when backend service is unavailable or times out

### DIFF
--- a/packages/auth/package-lock.json
+++ b/packages/auth/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@carto/toolkit-auth",
-	"version": "0.0.0",
+	"version": "0.0.1-rc.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/custom-storage/package-lock.json
+++ b/packages/custom-storage/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@carto/toolkit-custom-storage",
-	"version": "0.0.0",
+	"version": "0.0.1-rc.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sql/src/RequestManager.ts
+++ b/packages/sql/src/RequestManager.ts
@@ -7,7 +7,7 @@ interface FetchArgs {
   requestInfo: RequestInfo;
   requestInit: RequestInit | undefined;
   retries_no: number;
-  resolve: PromiseCb<JSON | string>;
+  resolve: PromiseCb<any>;
   reject: PromiseCb<Error | string>;
 }
 

--- a/packages/sql/src/constants.ts
+++ b/packages/sql/src/constants.ts
@@ -1,4 +1,8 @@
 export const DEFAULT_SERVER = 'https://{user}.carto.com/';
 export const PUBLIC_API_KEY = 'default_public';
-export const TOO_MANY_REQUESTS = 429;
 export const QUERY_LIMIT = 1024;
+
+export const HTTP_ERRORS = {
+  TOO_MANY_REQUESTS: 429,
+  SERVICE_UNAVAILABLE: 503
+};


### PR DESCRIPTION
This PR implements phased request replay when backend service is unavailable or there's a timeout error not related to rate limits (query takes too long).

I think we can hit some race conditions that would lead to retrying beyond attempts limit, but let's leave it like it is.

Related to #30 