### PR TITLE
Metrics use of client as Source on custom storage actions

### DIFF
--- a/packages/custom-storage/__tests__/CustomStorage.spec.ts
+++ b/packages/custom-storage/__tests__/CustomStorage.spec.ts
@@ -1,5 +1,23 @@
+import { Credentials } from '@carto/toolkit-core';
+import { CustomStorage } from '../src/CustomStorage';
+
 describe('CustomStorage', () => {
-  it('should have tests', () => {
-    expect(true).toBe(true);
+  const NAMESPACE = 'keplergl';
+  const someCredentials = new Credentials('aUser', 'anApiKey');
+
+  describe('client', () => {
+    it('should have a default client if not specified', () => {
+      const storage = new CustomStorage(NAMESPACE, someCredentials);
+      expect(storage.client).toBe(NAMESPACE);
+    });
+
+    it('should allow specifiying a different source', () => {
+      const options = {
+        client: 'carto-dashboard'
+      };
+      const storage = new CustomStorage(NAMESPACE, someCredentials, options);
+      expect(storage.client).not.toBe(NAMESPACE); // for tables
+      expect(storage.client).toBe(options.client); // for metrics events
+    });
   });
 });

--- a/packages/custom-storage/src/CustomStorage.ts
+++ b/packages/custom-storage/src/CustomStorage.ts
@@ -86,7 +86,7 @@ export class CustomStorage implements StorageRepository {
       COMMIT;
     `);
 
-    const event = new MetricsEvent(this._namespace, CONTEXT_INIT);
+    const event = new MetricsEvent(this.client, CONTEXT_INIT);
     const inits = await Promise.all([this._publicSQLStorage.init({ event }), this._privateSQLStorage.init({ event })]);
 
     const storageHasBeenInitialized = inits[0] || inits[1];
@@ -96,7 +96,7 @@ export class CustomStorage implements StorageRepository {
   public getVisualizations(): Promise<StoredVisualization[]> {
     this._checkReady();
 
-    const event = new MetricsEvent(this._namespace, CONTEXT_GET_ALL_VIS);
+    const event = new MetricsEvent(this.client, CONTEXT_GET_ALL_VIS);
     return Promise.all([
       this._privateSQLStorage.getVisualizations({ event }),
       this._publicSQLStorage.getVisualizations({ event })
@@ -108,21 +108,21 @@ export class CustomStorage implements StorageRepository {
   public getPublicVisualizations(): Promise<StoredVisualization[]> {
     this._checkReady();
 
-    const event = new MetricsEvent(this._namespace, CONTEXT_GET_PUBLIC_VIS);
+    const event = new MetricsEvent(this.client, CONTEXT_GET_PUBLIC_VIS);
     return this._publicSQLStorage.getVisualizations({ event });
   }
 
   public getPrivateVisualizations(): Promise<StoredVisualization[]> {
     this._checkReady();
 
-    const event = new MetricsEvent(this._namespace, CONTEXT_GET_PRIVATE_VIS);
+    const event = new MetricsEvent(this.client, CONTEXT_GET_PRIVATE_VIS);
     return this._privateSQLStorage.getVisualizations({ event });
   }
 
   public getVisualization(id: string): Promise<CompleteVisualization | null> {
     this._checkReady();
 
-    const event = new MetricsEvent(this._namespace, CONTEXT_GET_VIS);
+    const event = new MetricsEvent(this.client, CONTEXT_GET_VIS);
 
     // Alternatively: SELECT * from (SELECT * FROM <public_table> UNION SELECT * FROM <private_table>) WHERE id = ${id};
     return Promise.all([
@@ -137,7 +137,7 @@ export class CustomStorage implements StorageRepository {
   public deleteVisualization(id: string) {
     this._checkReady();
 
-    const event = new MetricsEvent(this._namespace, CONTEXT_DELETE_VIS);
+    const event = new MetricsEvent(this.client, CONTEXT_DELETE_VIS);
 
     return Promise.all([
       this._publicSQLStorage.deleteVisualization(id, { event }),
@@ -157,7 +157,7 @@ export class CustomStorage implements StorageRepository {
 
     const target = vis.isPrivate ? this._privateSQLStorage : this._publicSQLStorage;
 
-    const event = new MetricsEvent(this._namespace, CONTEXT_CREATE_VIS);
+    const event = new MetricsEvent(this.client, CONTEXT_CREATE_VIS);
     return target.createVisualization(vis, datasets, { overwriteDatasets, event });
   }
 
@@ -166,7 +166,7 @@ export class CustomStorage implements StorageRepository {
 
     const target = vis.isPrivate ? this._privateSQLStorage : this._publicSQLStorage;
 
-    const event = new MetricsEvent(this._namespace, CONTEXT_UPDATE_VIS);
+    const event = new MetricsEvent(this.client, CONTEXT_UPDATE_VIS);
     return target.updateVisualization(vis, datasets, { event });
   }
 

--- a/packages/custom-storage/src/CustomStorage.ts
+++ b/packages/custom-storage/src/CustomStorage.ts
@@ -10,6 +10,8 @@ import {
   Visualization
 } from './StorageRepository';
 
+const DEFAULT_CLIENT = 'keplergl'; // default client app using the storage
+
 const CONTEXT_INIT = 'custom_storage_init';
 const CONTEXT_CREATE_VIS = 'custom_storage_visualization_create';
 const CONTEXT_UPDATE_VIS = 'custom_storage_visualization_update';
@@ -22,29 +24,40 @@ const CONTEXT_GET_VIS = 'custom_storage_visualization_load';
 export class CustomStorage implements StorageRepository {
   public static version: number = 0;
 
+  public client: string;
+
   private _publicSQLStorage: SQLStorage;
   private _privateSQLStorage: SQLStorage;
   private _sqlClient: SQL;
   private _namespace: string;
 
   constructor(
-    namespace: string,
-    credentials: Credentials,
-    maxApiRequestsRetries: number = Constants.DEFAULT_MAX_API_REQUESTS_RETRIES) {
+      namespace: string,
+      credentials: Credentials,
+      options: {
+        client?: string
+        maxApiRequestsRetries?: number,
+      } = {}
+    ) {
+      const opts = Object.assign({
+        client: DEFAULT_CLIENT,
+        maxApiRequestsRetries: Constants.DEFAULT_MAX_API_REQUESTS_RETRIES,
+      }, options);
 
-    this._sqlClient = new SQL(credentials, { maxApiRequestsRetries });
-    this._checkNamespace(namespace);
+      this.client = opts.client;
+      this._sqlClient = new SQL(credentials, { maxApiRequestsRetries: opts.maxApiRequestsRetries });
+      this._checkNamespace(namespace);
 
-    this._namespace = namespace;
+      this._namespace = namespace;
 
-    this._publicSQLStorage = new SQLStorage(
+      this._publicSQLStorage = new SQLStorage(
       this._namespace,
       this._sqlClient,
       this.getVersion(),
       true
     );
 
-    this._privateSQLStorage = new SQLStorage(
+      this._privateSQLStorage = new SQLStorage(
       this._namespace,
       this._sqlClient,
       this.getVersion(),

--- a/packages/custom-storage/src/sql/PublicSQLReader.ts
+++ b/packages/custom-storage/src/sql/PublicSQLReader.ts
@@ -13,9 +13,8 @@ const CONTEXT_GET_PUBLIC_VIS = 'public_sql_reader_visualization_load';
 
 export class PublicSQLReader {
 
-  private client: string;
+  private _client: string;
 
-  private _namespace: string;
   private _clientMap: SQLClientMap;
   private _serverUrlTemplate: string;
 
@@ -28,14 +27,11 @@ export class PublicSQLReader {
       serverUrlTemplate: string = Credentials.DEFAULT_SERVER_URL_TEMPLATE,
       options: {
         client?: string
-      } = {
-        client: DEFAULT_CLIENT
-      }
+      } = { }
     ) {
 
-      this.client = options.client;
+      this._client = options.client ? options.client : DEFAULT_CLIENT;
 
-      this._namespace = namespace;
       this._clientMap = {};
       this._serverUrlTemplate = serverUrlTemplate;
 
@@ -56,7 +52,7 @@ export class PublicSQLReader {
       visToDatasets: this._datasetsVisTableName
     };
 
-    const event = new MetricsEvent(this._namespace, CONTEXT_GET_PUBLIC_VIS);
+    const event = new MetricsEvent(this._client, CONTEXT_GET_PUBLIC_VIS);
 
     return getVisualization(tableNames, id, this._clientMap[username], { event });
   }

--- a/packages/custom-storage/src/sql/PublicSQLReader.ts
+++ b/packages/custom-storage/src/sql/PublicSQLReader.ts
@@ -7,9 +7,14 @@ interface SQLClientMap {
   [key: string]: SQL;
 }
 
+const DEFAULT_CLIENT = 'keplergl'; // default client app using the storage
+
 const CONTEXT_GET_PUBLIC_VIS = 'public_sql_reader_visualization_load';
 
 export class PublicSQLReader {
+
+  private client: string;
+
   private _namespace: string;
   private _clientMap: SQLClientMap;
   private _serverUrlTemplate: string;
@@ -18,14 +23,25 @@ export class PublicSQLReader {
   private _datasetTableName: string;
   private _datasetsVisTableName: string;
 
-  constructor(namespace: string, serverUrlTemplate: string = Credentials.DEFAULT_SERVER_URL_TEMPLATE) {
-    this._namespace = namespace;
-    this._clientMap = {};
-    this._serverUrlTemplate = serverUrlTemplate;
+  constructor(
+      namespace: string,
+      serverUrlTemplate: string = Credentials.DEFAULT_SERVER_URL_TEMPLATE,
+      options: {
+        client?: string
+      } = {
+        client: DEFAULT_CLIENT
+      }
+    ) {
 
-    this._tableName = generateVisTableName(namespace, true, CustomStorage.version);
-    this._datasetTableName = generateDatasetTableName(this._tableName);
-    this._datasetsVisTableName = generateDatasetVisTableName(this._tableName);
+      this.client = options.client;
+
+      this._namespace = namespace;
+      this._clientMap = {};
+      this._serverUrlTemplate = serverUrlTemplate;
+
+      this._tableName = generateVisTableName(namespace, true, CustomStorage.version);
+      this._datasetTableName = generateDatasetTableName(this._tableName);
+      this._datasetsVisTableName = generateDatasetVisTableName(this._tableName);
   }
 
   public getVisualization(username: string, id: string) {

--- a/packages/toolkit/src/App.ts
+++ b/packages/toolkit/src/App.ts
@@ -68,7 +68,7 @@ class App {
     this._customStorage = new CustomStorage(
       this._namespace,
       credentials,
-      this._maxApiRequestsRetries
+      { maxApiRequestsRetries: this._maxApiRequestsRetries }
     );
     this._sql = this._customStorage.getSQLClient();
 


### PR DESCRIPTION
Identify client app using the custom-storage features. It allows a different 'source' when using metrics events, while using the same namespace for the tables.

Previous 'keplergl' events would be from now on restricted to the use the app from kepler.gl, while new custom 'client' parameter will allow to identify other sources (such as *carto-dashboard*)