### PR TITLE
Adding the bufferSize option to the mapconfig

### DIFF
--- a/packages/maps/src/Client.ts
+++ b/packages/maps/src/Client.ts
@@ -115,7 +115,7 @@ export interface AggregationColumn {
 }
 
 export interface MapOptions {
-  bufferSize: BufferSizeOptions;
+  bufferSize?: BufferSizeOptions;
   sql?: string;
   dataset?: string;
   vectorExtent: number;

--- a/packages/maps/src/Client.ts
+++ b/packages/maps/src/Client.ts
@@ -23,7 +23,8 @@ export class Maps {
       vectorExtent = 2048,
       vectorSimplifyExtent = 2048,
       metadata = {},
-      aggregation = {}
+      aggregation = {},
+      bufferSize
     } = options;
 
     if (!(sql || dataset)) {
@@ -32,6 +33,7 @@ export class Maps {
 
     const mapConfig = {
       version: '1.3.1',
+      buffersize: bufferSize,
       layers: [
         {
           type: 'mapnik',
@@ -113,6 +115,7 @@ export interface AggregationColumn {
 }
 
 export interface MapOptions {
+  bufferSize: BufferSizeOptions;
   sql?: string;
   dataset?: string;
   vectorExtent: number;
@@ -126,6 +129,12 @@ export interface MapOptions {
     threshold?: number;
     columns?: Record<string, AggregationColumn>;
   };
+}
+
+interface BufferSizeOptions {
+  png: number;
+  'grid.json': number;
+  mvt: number;
 }
 
 export interface MapInstance {


### PR DESCRIPTION
This option could be configured at layer level. Example:

```javascript
const mapOptions = {
  bufferSize: {
    mvt: 64
  }
};
const airbnbLayer = new carto.viz.Layer(
  'listings_madrid',
  availabilityStyle,
  {
    mapOptions
  }
);
```

However, according to the [MapConfig specification](https://github.com/CartoDB/Windshaft/blob/47e9e108dd6bb34820af2ea2e29d730bde3e4552/doc/MapConfig-specification.md) this option is especified at `LayerGroup` so maybe it should be defined as map option instead of a layer option.