### PR TITLE
Allow to use multiple layers at same time

### DIFF
--- a/packages/viz/src/lib/Layer.ts
+++ b/packages/viz/src/lib/Layer.ts
@@ -19,9 +19,21 @@ export class Layer {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _deckLayer: any | undefined;
 
-  constructor(source: string | Source, styles = {}) {
+  private _options: LayerOptions;
+
+  constructor(
+    source: string | Source,
+    styles = {},
+    options: LayerOptions = {}
+  ) {
     this._source = buildSource(source);
     this._styles = new Style(styles);
+
+    const defaultId = `${this._source.id}-${Date.now()}`;
+    this._options = {
+      id: defaultId,
+      ...options
+    };
   }
 
   /**
@@ -79,6 +91,7 @@ export class Layer {
 
     const layerProperties = Object.assign(
       props,
+      this._options,
       defaultStyles[props.geometryType].getProperties(),
       this._styles.getProperties()
     );
@@ -122,6 +135,16 @@ export class Layer {
 
     return this._deckLayer;
   }
+}
+
+/**
+ * Options of the layer
+ */
+interface LayerOptions {
+  /**
+   * id of the layer
+   */
+  id?: string;
 }
 
 /**

--- a/packages/viz/src/lib/sources/CARTOSource.ts
+++ b/packages/viz/src/lib/sources/CARTOSource.ts
@@ -21,11 +21,6 @@ function getSourceType(source: string) {
 }
 
 interface CARTOLayerProps extends LayerProps {
-  /**
-   * id of the layer
-   */
-  id?: string;
-
   // Tile URL template. It should be in the format of https://server/{z}/{x}/{y}..
   data: string | Array<string>;
 }
@@ -85,9 +80,7 @@ export class CARTOSource extends Source {
       'ST_'
     )[1];
 
-    const { id } = this;
-
-    return { id, data: urlTemplate, geometryType };
+    return { data: urlTemplate, geometryType };
   }
 
   public get value(): string {

--- a/packages/viz/src/lib/sources/CARTOSource.ts
+++ b/packages/viz/src/lib/sources/CARTOSource.ts
@@ -21,6 +21,11 @@ function getSourceType(source: string) {
 }
 
 interface CARTOLayerProps extends LayerProps {
+  /**
+   * id of the layer
+   */
+  id?: string;
+
   // Tile URL template. It should be in the format of https://server/{z}/{x}/{y}..
   data: string | Array<string>;
 }
@@ -80,7 +85,9 @@ export class CARTOSource extends Source {
       'ST_'
     )[1];
 
-    return { data: urlTemplate, geometryType };
+    const { id } = this;
+
+    return { id, data: urlTemplate, geometryType };
   }
 
   public get value(): string {


### PR DESCRIPTION
This fixes the error thrown by adding two or more layers to the same
map instance. The error occurred because all layers had the same id.

With this fix, each layer has the id of its source.