### PR TITLE
Fix lines size in size helpers

### DIFF
--- a/examples/visualization/styles/helpers/size-categories-style.html
+++ b/examples/visualization/styles/helpers/size-categories-style.html
@@ -37,20 +37,20 @@
 
     <script>
       async function initialize() {
-        carto.setDefaultCredentials({ username: 'public' });
+        carto.setDefaultCredentials({ username: 'cartoframes' });
 
         const deckMap = carto.viz.createMap({
           basemap: 'voyager',
           view: {
-            longitude: -3.700385991742541,
-            latitude: 40.41532659629741,
-            zoom: 12
+            longitude: 135.70,
+            latitude: -25.48,
+            zoom: 3
           }
         });
 
-        const roomTypeStyle = carto.viz.sizeCategoriesStyle('room_type');
+        const roomTypeStyle = carto.viz.sizeCategoriesStyle('type');
 
-        const airbnbSource = new carto.viz.CARTOSource('listings_madrid', {
+        const airbnbSource = new carto.viz.CARTOSource('roads', {
           mapOptions: {
             bufferSize: {
               mvt: 30
@@ -58,7 +58,7 @@
           }
         });
         const airbnbLayer = new carto.viz.Layer(airbnbSource, roomTypeStyle);
-        airbnbLayer.addTo(deckMap);        
+        airbnbLayer.addTo(deckMap);
       }
 
       initialize();

--- a/packages/viz/src/lib/style/helpers/size-bins-style.ts
+++ b/packages/viz/src/lib/style/helpers/size-bins-style.ts
@@ -114,7 +114,7 @@ function calculateWithBreaks(
     }
 
     const featureValueIndex = findIndexForBinBuckets(ranges, featureValue);
-    return pixel2meters(sizes[featureValueIndex], layerStyle);
+    return sizes[featureValueIndex];
   };
 
   /**
@@ -126,7 +126,7 @@ function calculateWithBreaks(
    * @returns radio size.
    */
   const getRadius = (feature: Record<string, any>) => {
-    return getSizeValue(feature);
+    return pixel2meters(getSizeValue(feature), layerStyle);
   };
 
   /**

--- a/packages/viz/src/lib/style/helpers/size-categories-style.ts
+++ b/packages/viz/src/lib/style/helpers/size-categories-style.ts
@@ -112,7 +112,7 @@ function calculateWithCategories(
     }
 
     const featureValueIndex = categories.indexOf(featureValue);
-    return pixel2meters(sizes[featureValueIndex], layer);
+    return sizes[featureValueIndex];
   };
 
   /**
@@ -124,7 +124,7 @@ function calculateWithCategories(
    * @returns radio size.
    */
   const getRadius = (feature: Record<string, any>) => {
-    return getSizeValue(feature);
+    return pixel2meters(getSizeValue(feature), layer);
   };
 
   /**

--- a/packages/viz/src/lib/style/helpers/size-continuous-style.ts
+++ b/packages/viz/src/lib/style/helpers/size-continuous-style.ts
@@ -86,15 +86,13 @@ function calculate(
       return options.nullSize;
     }
 
-    const size = range(
+    return range(
       rangeMin,
       rangeMax,
       options.sizeRange[0],
       options.sizeRange[1],
       featureValue
     );
-
-    return pixel2meters(size, layerStyle);
   };
 
   /**
@@ -106,7 +104,7 @@ function calculate(
    * @returns radio size.
    */
   const getRadius = (feature: Record<string, any>) => {
-    return getSizeValue(feature);
+    return pixel2meters(getSizeValue(feature), layerStyle);
   };
 
   /**


### PR DESCRIPTION
Deck.gl expects different behavior with lines and points:
- points: works with meters, so we need to call `pixel2meters`
- lines: works with pixels and we don't need to call `pixel2meters`

I have changed the 3 size helpers