### PR TITLE
Fix stroke color in color helpers for points and polygons

### DIFF
--- a/examples/_debug/styles/basic-style.html
+++ b/examples/_debug/styles/basic-style.html
@@ -93,10 +93,10 @@
         });
 
         const basicStyle = carto.viz.basicStyle({
-          // color: '#0000FF',
-          // size: 14,
-          // strokeColor: '#00FF00',
-          // strokeWidth: 10
+          color: '#0000FF',
+          size: 10,
+          strokeColor: '#0000FF44',
+          strokeWidth: 10
         });
         const layer = new carto.viz.Layer('sf_nbhd_crime', basicStyle);
         layer.addTo(deckMap);

--- a/examples/_debug/styles/color-bins-style.html
+++ b/examples/_debug/styles/color-bins-style.html
@@ -58,21 +58,19 @@
       }
 
       function initializeLines() {
-        carto.setDefaultCredentials({ username: 'aromeu' });
+        carto.setDefaultCredentials({ username: 'cartoframes' });
 
         const deckMap = carto.viz.createMap({
           basemap: 'voyager',
           view: {
-            longitude: -83.96176338195801,
-            latitude: 40.71402088381144,
-            zoom: 4
+            longitude: 135.7,
+            latitude: -25.48,
+            zoom: 3
           }
         });
 
-        const style = carto.viz.colorBinsStyle('loss', {
-          method: 'stdev'
-        });
-        const layer = new carto.viz.Layer('aromeu.tornado_1', style);
+        const style = carto.viz.colorBinsStyle('length_km');
+        const layer = new carto.viz.Layer('roads', style);
         layer.addTo(deckMap);
       }
 
@@ -97,8 +95,8 @@
       }
 
       // initializePoints();
-      initializeLines();
-      // initializePolygons();
+      // initializeLines();
+      initializePolygons();
     </script>
   </body>
 </html>

--- a/examples/_debug/styles/color-categories-style.html
+++ b/examples/_debug/styles/color-categories-style.html
@@ -64,7 +64,7 @@
           }
         });
 
-        const style = carto.viz.colorCategoriesStyle('length_km');
+        const style = carto.viz.colorCategoriesStyle('type');
         const layer = new carto.viz.Layer('roads', style);
         layer.addTo(deckMap);
       }
@@ -107,8 +107,8 @@
       }
 
       // initializePoints();
-      initializePolygons();
-      // initializeLines();
+      // initializePolygons();
+      initializeLines();
       // initializePolygons2();
     </script>
   </body>

--- a/examples/_debug/styles/color-categories-style.html
+++ b/examples/_debug/styles/color-categories-style.html
@@ -35,24 +35,41 @@
     <script src="/packages/toolkit/dist/umd/index.min.js"></script>
 
     <script>
-      function initializeLines() {
-        carto.setDefaultCredentials({ username: 'aromeu' });
+      function initializePoints() {
+        carto.setDefaultCredentials({ username: 'cartoframes' });
 
         const deckMap = carto.viz.createMap({
           basemap: 'voyager',
           view: {
-            longitude: -73.96176338195801,
-            latitude: 40.71402088381144,
-            zoom: 4
+            longitude: -122.45292663574217,
+            latitude: 37.760944207425965,
+            zoom: 11
           }
         });
 
-        const style = carto.viz.colorCategoriesStyle('st');
-        const layer = new carto.viz.Layer('aromeu.tornado_1', style);
+        const style = carto.viz.colorCategoriesStyle('category');
+        const layer = new carto.viz.Layer('sf_nbhd_crime', style);
         layer.addTo(deckMap);
       }
 
-      function initializePoints() {
+      function initializeLines() {
+        carto.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: 135.7,
+            latitude: -25.48,
+            zoom: 3
+          }
+        });
+
+        const style = carto.viz.colorCategoriesStyle('length_km');
+        const layer = new carto.viz.Layer('roads', style);
+        layer.addTo(deckMap);
+      }
+
+      function initializePolygons() {
         carto.setDefaultCredentials({ username: 'cartoframes' });
 
         const deckMap = carto.viz.createMap({
@@ -69,8 +86,30 @@
         layer.addTo(deckMap);
       }
 
+      function initializePolygons2() {
+        carto.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -2.6806640625,
+            latitude: 53.48804553605622,
+            zoom: 6
+          }
+        });
+
+        const style = carto.viz.colorCategoriesStyle('region', {
+          // color: '#0000FF',
+          // size: 5
+        });
+        const layer = new carto.viz.Layer('eng_wales_pop', style);
+        layer.addTo(deckMap);
+      }
+
       // initializePoints();
-      initializeLines();
+      initializePolygons();
+      // initializeLines();
+      // initializePolygons2();
     </script>
   </body>
 </html>

--- a/packages/viz/src/lib/style/default-styles.ts
+++ b/packages/viz/src/lib/style/default-styles.ts
@@ -3,8 +3,8 @@
 const NULL_COLOR = '#ccc';
 const OTHERS_COLOR = '#777';
 const NULL_SIZE = 0;
-const STROKE_WIDTH = 1;
-const STROKE_COLOR = '#22222200';
+const STROKE_WIDTH = 0.5;
+const STROKE_COLOR = '#22222288';
 
 export const defaultStyles: any = {
   Point: {

--- a/packages/viz/src/lib/style/helpers/color-bins-style.ts
+++ b/packages/viz/src/lib/style/helpers/color-bins-style.ts
@@ -107,6 +107,7 @@ function calculateWithBreaks(
   const colors = getColors(options.palette, ranges.length);
   const rgbaNullColor = hexToRgb(options.nullColor);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const getFillColor = (feature: Record<string, any>) => {
     const featureValue = feature.properties[featureProperty];
 
@@ -119,14 +120,27 @@ function calculateWithBreaks(
     return hexToRgb(colors[featureValueIndex]);
   };
 
+  let geomStyles;
+
+  if (geometryType === 'Line') {
+    geomStyles = {
+      getLineColor: getFillColor,
+      updateTriggers: getUpdateTriggers({
+        getLineColor: getFillColor
+      })
+    };
+  } else {
+    geomStyles = {
+      getFillColor,
+      updateTriggers: getUpdateTriggers({
+        getFillColor
+      })
+    };
+  }
+
   return {
     ...styles,
-    getFillColor,
-    getLineColor: getFillColor,
-    updateTriggers: getUpdateTriggers({
-      getFillColor,
-      getLineColor: getFillColor
-    })
+    ...geomStyles
   };
 }
 

--- a/packages/viz/src/lib/style/helpers/color-categories-style.ts
+++ b/packages/viz/src/lib/style/helpers/color-categories-style.ts
@@ -62,13 +62,14 @@ export function colorCategoriesStyle(
       const stats = meta.stats.find(
         c => c.name === featureProperty
       ) as CategoryFieldStats;
-      categories = stats.categories.map((c: Category) => c.category);
 
-      if (!categories.length) {
+      if (!stats.categories || !stats.categories.length) {
         throw new CartoStylingError(
           `Current dataset has not categories for '${featureProperty}'`
         );
       }
+
+      categories = stats.categories.map((c: Category) => c.category);
     }
 
     // Apply top
@@ -113,14 +114,27 @@ function calculateWithCategories(
     return categoriesWithColors[category] || rgbaOthersColor;
   };
 
+  let geomStyles;
+
+  if (geometryType === 'Line') {
+    geomStyles = {
+      getLineColor: getFillColor,
+      updateTriggers: getUpdateTriggers({
+        getLineColor: getFillColor
+      })
+    };
+  } else {
+    geomStyles = {
+      getFillColor,
+      updateTriggers: getUpdateTriggers({
+        getFillColor
+      })
+    };
+  }
+
   return {
     ...styles,
-    getFillColor,
-    getLineColor: getFillColor,
-    updateTriggers: getUpdateTriggers({
-      getFillColor,
-      getLineColor: getFillColor
-    })
+    ...geomStyles
   };
 }
 

--- a/packages/viz/src/lib/style/helpers/color-continuous-style.ts
+++ b/packages/viz/src/lib/style/helpers/color-continuous-style.ts
@@ -92,14 +92,27 @@ function calculate(
     return colorScale(featureValue).rgb();
   };
 
+  let geomStyles;
+
+  if (geometryType === 'Line') {
+    geomStyles = {
+      getLineColor: getFillColor,
+      updateTriggers: getUpdateTriggers({
+        getLineColor: getFillColor
+      })
+    };
+  } else {
+    geomStyles = {
+      getFillColor,
+      updateTriggers: getUpdateTriggers({
+        getFillColor
+      })
+    };
+  }
+
   return {
     ...styles,
-    getFillColor,
-    getLineColor: getFillColor,
-    updateTriggers: getUpdateTriggers({
-      getFillColor,
-      getLineColor: getFillColor
-    })
+    ...geomStyles
   };
 }
 


### PR DESCRIPTION
https://app.clubhouse.io/cartoteam/story/76418/styles-missing-strokecolor-in-colorbinsstyle-example

This PR fixes stoke lines in polygons and point when using color helpers