### PR TITLE
Prevent adding the column carotbd_id as aggregation column

### DIFF
--- a/packages/viz/src/lib/layer/Layer.ts
+++ b/packages/viz/src/lib/layer/Layer.ts
@@ -16,6 +16,8 @@ import {
 } from './LayerInteractivity';
 import { LayerOptions } from './LayerOptions';
 
+const DEFAULT_ID_PROPERTY = 'cartodb_id';
+
 export class Layer extends WithEvents implements StyledLayer {
   private _source: Source;
   private _style: Style;
@@ -414,7 +416,8 @@ export class Layer extends WithEvents implements StyledLayer {
         {
           column: this._style.field,
           sample: true,
-          aggregation: true
+          // prevent aggregating by the id column
+          aggregation: this._style.field !== DEFAULT_ID_PROPERTY
         }
       ];
     }
@@ -427,7 +430,8 @@ export class Layer extends WithEvents implements StyledLayer {
         const field = {
           column,
           sample: false,
-          aggregation: true
+          // prevent aggregating by the id column
+          aggregation: column !== DEFAULT_ID_PROPERTY
         };
         this._fields.push(field);
       });

--- a/packages/viz/src/lib/sources/CARTOSource.ts
+++ b/packages/viz/src/lib/sources/CARTOSource.ts
@@ -149,7 +149,8 @@ export class CARTOSource extends Source {
 
     const dimensions: Record<string, { column: string }> = {};
     fields.forEach(field => {
-      if (field.aggregation) {
+      // prevent using cartodb_id as aggregation column
+      if (field.aggregation && field.column !== 'cartodb_id') {
         dimensions[field.column] = { column: field.column };
       }
     });

--- a/packages/viz/src/lib/sources/CARTOSource.ts
+++ b/packages/viz/src/lib/sources/CARTOSource.ts
@@ -11,6 +11,8 @@ import {
 import { parseGeometryType } from '../style/helpers/utils';
 import { sourceErrorTypes, SourceError } from '../errors/source-error';
 
+const DEFAULT_ID_PROPERTY = 'cartodb_id';
+
 export interface SourceOptions {
   credentials?: Credentials;
   mapOptions?: MapOptions;
@@ -149,8 +151,8 @@ export class CARTOSource extends Source {
 
     const dimensions: Record<string, { column: string }> = {};
     fields.forEach(field => {
-      // prevent using cartodb_id as aggregation column
-      if (field.aggregation && field.column !== 'cartodb_id') {
+      // prevent aggregating by the id column
+      if (field.aggregation && field.column !== DEFAULT_ID_PROPERTY) {
         dimensions[field.column] = { column: field.column };
       }
     });

--- a/packages/viz/src/lib/sources/CARTOSource.ts
+++ b/packages/viz/src/lib/sources/CARTOSource.ts
@@ -11,8 +11,6 @@ import {
 import { parseGeometryType } from '../style/helpers/utils';
 import { sourceErrorTypes, SourceError } from '../errors/source-error';
 
-const DEFAULT_ID_PROPERTY = 'cartodb_id';
-
 export interface SourceOptions {
   credentials?: Credentials;
   mapOptions?: MapOptions;
@@ -151,8 +149,7 @@ export class CARTOSource extends Source {
 
     const dimensions: Record<string, { column: string }> = {};
     fields.forEach(field => {
-      // prevent aggregating by the id column
-      if (field.aggregation && field.column !== DEFAULT_ID_PROPERTY) {
+      if (field.aggregation) {
         dimensions[field.column] = { column: field.column };
       }
     });


### PR DESCRIPTION
This fixes the error `column reference "cartodb_id" is ambiguous` thrown by Maps API when we add the column `cartodb_id` whithin the popups.